### PR TITLE
postgres用にDocker用意

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,15 @@
 # Docs
 
-https://mj-scorekeeper.herokuapp.com/
+https://tolymer.kibe.la/notes/tree/mj-scorekeeper
+
+## Required
+
+- [Docker](https://docs.docker.com/install/)
 
 ## Development
 
 ```
+$ docker-compose up -d
 $ bundle install
 $ bin/rake db:create
 $ bin/rake ridgepole:apply

--- a/config/database.yml
+++ b/config/database.yml
@@ -29,19 +29,19 @@ development:
   # To create additional roles in postgres see `$ createuser --help`.
   # When left blank, postgres will use the default role. This is
   # the same name as the operating system user that initialized the database.
-  #username: mj-scorekeeper
+  username: postgres
 
   # The password associated with the postgres role (username).
-  #password:
+  password:
 
   # Connect on a TCP socket. Omitted by default since the client uses a
   # domain socket that doesn't need configuration. Windows does not have
   # domain sockets, so uncomment these lines.
-  #host: localhost
+  host: localhost
 
   # The TCP port the server listens on. Defaults to 5432.
   # If your server runs on a different port number, change accordingly.
-  #port: 5432
+  port: 54320
 
   # Schema search path. The server defaults to $user,public
   #schema_search_path: myapp,sharedapp,public
@@ -58,6 +58,10 @@ development:
 test:
   <<: *default
   database: mj-scorekeeper_test
+  username: postgres
+  password:
+  host: localhost
+  port: 54320
 
 # As with config/secrets.yml, you never want to store sensitive information,
 # like your database password, in your source code. If your source code is

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,6 @@
+version: '3'
+services:
+  db:
+    image: postgres:9.6.6
+    ports:
+      - 54320:5432


### PR DESCRIPTION
# これは何？

postgres用のdockerを用意しました。
これでpostgresの環境構築をしないで済むので、谷さんとかが環境構築しやすい？
他にも何か追加するかもしれない（Redisとか）ので、docker-composeで用意してます。
rails自体をDockerに載せるのは嫌な思い出しかないのでやってません。

# テスト

Docker立ち上げ後、dbのmigrationを走らせる。

```
[tan-yuki@macbook] % docker-compose up -d                                                     [(master) ~/workspace/mj-scorekeeper]
Recreating mjscorekeeper_db_1 ... done
[tan-yuki@macbook] % bin/rake db:create                                                       [(master) ~/workspace/mj-scorekeeper]
Created database 'mj-scorekeeper_development'
Created database 'mj-scorekeeper_test'
[tan-yuki@macbook] % bin/rake ridgepole:apply                                                 [(master) ~/workspace/mj-scorekeeper]
ridgepole --config config/database.yml --env development --apply --file db/Schemafile.rb
Apply `db/Schemafile.rb`
-- create_table("games", {})
   -> 0.0073s
-- add_index("games", ["event_id", "created_at"], {:name=>"idx_event_id_created_at", :using=>:btree})
   -> 0.0150s
-- create_table("groups", {})
   -> 0.0075s
-- add_index("groups", ["name"], {:name=>"idx_groups_user_id", :using=>:btree})
   -> 0.0054s
-- create_table("events", {})
   -> 0.0095s
-- add_index("events", ["group_id"], {:name=>"idx_group_id", :using=>:btree})
   -> 0.0050s
-- create_table("group_members", {})
   -> 0.0043s
-- add_index("group_members", ["user_id", "group_id"], {:name=>"idx_user_id_group_id", :unique=>true, :using=>:btree})
   -> 0.0060s
-- create_table("game_scores", {})
   -> 0.0110s
-- add_index("game_scores", ["game_id", "user_id"], {:name=>"idx_game_id_user_id", :using=>:btree})
   -> 0.0068s
-- create_table("users", {})
   -> 0.0073s
-- add_index("users", ["name"], {:name=>"idx_name", :unique=>true, :using=>:btree})
   -> 0.0092s
-- create_table("event_members", {})
   -> 0.0049s
-- add_index("event_members", ["user_id", "event_id"], {:name=>"idx_user_id_event_id", :unique=>true, :using=>:btree})
   -> 0.0062s
```


### docker processの確認

`docker-compose ps`でdockerの状態を確認

```
[tan-yuki@macbook] % docker-compose ps                                             [(add-docker-for-pg) ~/workspace/mj-scorekeeper]
       Name                     Command              State            Ports
------------------------------------------------------------------------------------
mjscorekeeper_db_1   docker-entrypoint.sh postgres   Up      0.0.0.0:54320->5432/tcp

```

### postgresの中身を確認

```
[tan-yuki@macbook] % psql -U postgres -p 54320 -h localhost                        [(add-docker-for-pg) ~/workspace/mj-scorekeeper]
psql (9.6.3, server 9.6.6)
Type "help" for help.

postgres=# \l
 mj-scorekeeper_development | postgres | UTF8     | en_US.utf8 | en_US.utf8 |
 mj-scorekeeper_test        | postgres | UTF8     | en_US.utf8 | en_US.utf8 |
 postgres                   | postgres | UTF8     | en_US.utf8 | en_US.utf8 |
 template0                  | postgres | UTF8     | en_US.utf8 | en_US.utf8 | =c/postgres          +
                            |          |          |            |            | postgres=CTc/postgres
 template1                  | postgres | UTF8     | en_US.utf8 | en_US.utf8 | =c/postgres          +
                            |          |          |            |            | postgres=CTc/postgres
postgres=# \c mj-scorekeeper_development
psql (9.6.3, server 9.6.6)
You are now connected to database "mj-scorekeeper_development" as user "postgres".
mj-scorekeeper_development=# \d
 public | event_members        | table    | postgres
 public | event_members_id_seq | sequence | postgres
 public | events               | table    | postgres
 public | events_id_seq        | sequence | postgres
 public | game_scores          | table    | postgres
 public | game_scores_id_seq   | sequence | postgres
 public | games                | table    | postgres
 public | games_id_seq         | sequence | postgres
 public | group_members        | table    | postgres
 public | group_members_id_seq | sequence | postgres
 public | groups               | table    | postgres
 public | groups_id_seq        | sequence | postgres
 public | users                | table    | postgres
 public | users_id_seq         | sequence | postgres
```
