### PR TITLE
Join to group with current user

### DIFF
--- a/app/controllers/group_members_controller.rb
+++ b/app/controllers/group_members_controller.rb
@@ -6,8 +6,7 @@ class GroupMembersController < ApplicationController
 
   def create
     group = Group.find(params[:group_id])
-    user = User.find(params[:user_id])
-    group.members << user
-    render json: user, status: 201
+    group.members << current_user
+    render json: { result: 'ok' }, status: 201
   end
 end

--- a/docs/swagger/paths/group_members.yml
+++ b/docs/swagger/paths/group_members.yml
@@ -19,6 +19,7 @@
           items:
             $ref: '#definitions/User'
   post:
+    description: Join to group with current user
     tags:
       - group_members
     security:
@@ -30,18 +31,12 @@
         required: true
         type: integer
         format: int64
-      - in: body
-        name: body
-        required: true
+    responses:
+      '201':
+        description: Created group member
         schema:
           type: object
           properties:
-            user_id:
-              type: integer
-              format: int64
-              example: 1
-    responses:
-      '201':
-        description: Create group member
-        schema:
-          $ref: '#definitions/User'
+            result:
+              type: string
+              example: ok

--- a/spec/requests/group_members_spec.rb
+++ b/spec/requests/group_members_spec.rb
@@ -32,14 +32,13 @@ describe 'group members API' do
 
   describe 'POST /groups/:group_id/members' do
     let(:group) { FactoryBot.create(:group) }
-    let(:user) { FactoryBot.create(:user) }
-    before { post "/groups/#{group.id}/members", params: { user_id: user.id }, headers: headers }
+    before { post "/groups/#{group.id}/members", headers: headers }
 
     specify do
       expect(status).to be 201
-      expect(body).to eq({ 'id' => user.id, 'name' => user.name })
+      expect(body).to eq({ 'result' => 'ok' })
       expect(group.members.size).to eq 1
-      expect(group.members.take).to eq user
+      expect(group.members.take).to eq current_user
     end
   end
 end


### PR DESCRIPTION
グループへのメンバーの追加を他人がやることはない（あってもinvite）のでcurrent_userを追加するAPIに変更。inviteできる機能は別途必要。