### PR TITLE
mapping local port to postgres docker service

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,8 @@ services:
     environment:
       POSTGRES_USER: postgres
       POSTGRES_PASSWORD: password
+    ports:
+      - '5432:5432'
     volumes:
        - db-data:/var/lib/postgresql/data
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
       POSTGRES_USER: postgres
       POSTGRES_PASSWORD: password
     ports:
-      - '5432:5432'
+      - '15432:5432'
     volumes:
        - db-data:/var/lib/postgresql/data
 


### PR DESCRIPTION
# 概要

<img width="649" alt="_2018_04_01_22_13" src="https://user-images.githubusercontent.com/307352/38173458-fb65c470-35f9-11e8-8a80-c4224528b4f7.png">

こーいうGUIでデータみたいので、ローカルのポートとバインディングさせてほしいです 🙏 

# テスト

```
[tan-yuki@macbook] % docker-compose build                                                        [(master) ~/workspace/tolymer-api]
db uses an image, skipping
Building app
Step 1/4 : FROM ruby:2.5.0
 ---> 213a086149f6
Step 2/4 : ENV LANG C.UTF-8
 ---> Using cache
 ---> 2cae5928eb13
Step 3/4 : RUN apt-get update -qq &&     apt-get install -y --no-install-recommends build-essential libpq-dev postgresql-client &&     rm -rf /var/lib/apt/lists/*
 ---> Using cache
 ---> bd35ffb74903
Step 4/4 : WORKDIR /app
 ---> Using cache
 ---> ecc79e772030

Successfully built ecc79e772030
Successfully tagged tolymerapi_app:latest
swagger-ui uses an image, skipping
[tan-yuki@macbook] % docker-compose up -d                                                        [(master) ~/workspace/tolymer-api]
tolymerapi_swagger-ui_1 is up-to-date
Recreating tolymerapi_db_1 ... done
Recreating tolymerapi_app_1 ... done
[tan-yuki@macbook] % docker-compose ps                                                           [(master) ~/workspace/tolymer-api]
         Name                        Command               State           Ports
-----------------------------------------------------------------------------------------
tolymerapi_app_1          script/start.sh                  Up      0.0.0.0:3000->3000/tcp
tolymerapi_db_1           docker-entrypoint.sh postgres    Up      0.0.0.0:5432->5432/tcp
tolymerapi_swagger-ui_1   sh /usr/share/nginx/docker ...   Up      0.0.0.0:8080->8080/tcp
```

