### PR TITLE
Tip API

### DIFF
--- a/app/controllers/tips_controller.rb
+++ b/app/controllers/tips_controller.rb
@@ -1,0 +1,15 @@
+class TipsController < ApplicationController
+  def index
+    event = Event.find(params[:event_id])
+    render json: event.tips.all
+  end
+
+  def create
+    event = Event.find(params[:event_id])
+    event.transaction do
+      event.tips.destroy_all
+      params[:tips].each { |tip| event.tips.create!(user_id: tip[:user_id], point: tip[:point]) }
+    end
+    render json: { result: 'ok' }, status: 200
+  end
+end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -2,6 +2,7 @@ class Event < ApplicationRecord
   has_many :event_members
   has_many :members, through: :event_members, source: :user
   has_many :games
+  has_many :tips
 
   belongs_to :group
 

--- a/app/models/tip.rb
+++ b/app/models/tip.rb
@@ -1,0 +1,8 @@
+class Tip < ApplicationRecord
+  belongs_to :user
+  belongs_to :event
+
+  def as_json(options)
+    super(only: [:user_id, :point])
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,6 +10,7 @@ Rails.application.routes.draw do
     resources :events, only: %i(index show create update), shallow: true do
       resources :members, only: %i(index create), controller: 'event_members'
       resources :games, only: %i(index create update)
+      resources :tips, only: %i(index create)
     end
   end
 

--- a/db/schema/game_scores.rb
+++ b/db/schema/game_scores.rb
@@ -1,8 +1,8 @@
 create_table 'game_scores', force: :cascade do |t|
-  t.bigint   'game_id', null: false
+  t.bigint   'game_id',  null: false
   t.bigint   'user_id',  null: false
   t.integer  'point',    null: false
   t.integer  'rank',     null: false
 end
 
-add_index 'game_scores', ['game_id', 'user_id'], name: 'idx_game_id_user_id', using: :btree
+add_index 'game_scores', ['game_id', 'user_id'], name: 'idx_game_id_user_id', unique: true, using: :btree

--- a/db/schema/tips.rb
+++ b/db/schema/tips.rb
@@ -1,0 +1,7 @@
+create_table 'tips', force: :cascade do |t|
+  t.bigint   'event_id', null: false
+  t.bigint   'user_id',  null: false
+  t.integer  'point',    null: false
+end
+
+add_index 'tips', ['event_id', 'user_id'], name: 'idx_event_id_user_id', unique: true, using: :btree

--- a/docs/swagger/paths/event_tips.yml
+++ b/docs/swagger/paths/event_tips.yml
@@ -1,0 +1,76 @@
+'/events/{event_id}/tips':
+  get:
+    tags:
+      - event_tips
+    security:
+      - Bearer: []
+    parameters:
+      - in: path
+        name: event_id
+        description: event id
+        required: true
+        type: integer
+        format: int64
+    responses:
+      '200':
+        description: Return event tips
+        schema:
+          type: array
+          items:
+            type: object
+            properties:
+              user_id:
+                type: integer
+                format: int64
+              point:
+                type: integer
+                format: int32
+          example:
+            - { user_id: 1, point: 10 }
+            - { user_id: 2, point: -10 }
+            - { user_id: 3, point: 40 }
+            - { user_id: 4, point: -40 }
+
+  post:
+    tags:
+      - event_tips
+    security:
+      - Bearer: []
+    parameters:
+      - in: path
+        name: event_id
+        description: event id
+        required: true
+        type: integer
+        format: int64
+      - in: body
+        name: body
+        required: true
+        schema:
+          type: object
+          properties:
+            tip:
+              type: array
+              items:
+                type: object
+                properties:
+                  user_id:
+                    type: integer
+                    format: int64
+                  point:
+                    type: integer
+                    format: int32
+              example:
+                - { user_id: 1, point: 10 }
+                - { user_id: 2, point: -10 }
+                - { user_id: 3, point: 40 }
+                - { user_id: 4, point: -40 }
+    responses:
+      '200':
+        description: Save the event tips
+        schema:
+          type: object
+          properties:
+            result:
+              type: string
+              example: ok

--- a/docs/swagger/root.yml
+++ b/docs/swagger/root.yml
@@ -17,3 +17,4 @@ tags:
   - name: event_members
   - name: event_games
   - name: games
+  - name: event_tips

--- a/spec/requests/event_tips_spec.rb
+++ b/spec/requests/event_tips_spec.rb
@@ -1,0 +1,101 @@
+require 'rails_helper'
+
+describe 'tips API' do
+  let(:current_user) { FactoryBot.create(:user) }
+  let(:headers) {
+    token = Knock::AuthToken.new(payload: { sub: current_user.id }).token
+    { Authorization: "Bearer #{token}" }
+  }
+
+  subject(:status) { response.status }
+  subject(:body) { JSON.parse(response.body) }
+
+  let(:event) { FactoryBot.create(:event) }
+  let(:user1) { FactoryBot.create(:user) }
+  let(:user2) { FactoryBot.create(:user) }
+  let(:user3) { FactoryBot.create(:user) }
+  let(:user4) { FactoryBot.create(:user) }
+
+  describe 'GET /events/:event_id/tip' do
+    let(:now) { Time.now }
+
+    before do
+      event.tips.create!(user: user1, point: 10)
+      event.tips.create!(user: user2, point: -10)
+      event.tips.create!(user: user3, point: 20)
+      event.tips.create!(user: user4, point: -20)
+
+      get "/events/#{event.id}/tips", headers: headers
+    end
+
+    specify do
+      expect(status).to be 200
+      expect(body).to contain_exactly(
+        { 'user_id' => user1.id, 'point' => 10 },
+        { 'user_id' => user2.id, 'point' => -10 },
+        { 'user_id' => user3.id, 'point' => 20 },
+        { 'user_id' => user4.id, 'point' => -20 },
+      )
+    end
+  end
+
+  describe 'POST /events/:event_id/tips' do
+    let(:params) do
+      {
+        tips: [
+          { user_id: user1.id, point: 10 },
+          { user_id: user2.id, point: -10 },
+          { user_id: user3.id, point: 30 },
+          { user_id: user4.id, point: -30 },
+        ]
+      }
+    end
+
+    specify do
+      post "/events/#{event.id}/tips", params: params, headers: headers
+
+      expect(status).to be 200
+      expect(event.tips.size).to be 4
+
+      user1_tip = event.tips.find_by(user_id: user1.id)
+      expect(user1_tip.point).to eq 10
+
+      user2_tip = event.tips.find_by(user_id: user2.id)
+      expect(user2_tip.point).to eq(-10)
+
+      user3_tip = event.tips.find_by(user_id: user3.id)
+      expect(user3_tip.point).to eq 30
+
+      user4_tip = event.tips.find_by(user_id: user4.id)
+      expect(user4_tip.point).to eq(-30)
+    end
+
+    context 'when tips are already exist' do
+      before do
+        event.tips.create!(user: user1, point: 1)
+        event.tips.create!(user: user2, point: -1)
+        event.tips.create!(user: user3, point: 2)
+        event.tips.create!(user: user4, point: -2)
+      end
+
+      it 'should override data' do
+        post "/events/#{event.id}/tips", params: params, headers: headers
+
+        expect(status).to be 200
+        expect(event.tips.size).to be 4
+
+        user1_tip = event.tips.find_by(user_id: user1.id)
+        expect(user1_tip.point).to eq 10
+
+        user2_tip = event.tips.find_by(user_id: user2.id)
+        expect(user2_tip.point).to eq(-10)
+
+        user3_tip = event.tips.find_by(user_id: user3.id)
+        expect(user3_tip.point).to eq 30
+
+        user4_tip = event.tips.find_by(user_id: user4.id)
+        expect(user4_tip.point).to eq(-30)
+      end
+    end
+  end
+end


### PR DESCRIPTION
チップのAPI実装した。

- イベントに対してチップは一つだけという制約にした
- `/events/:id/tips`にPOSTで作成、更新（上書き）の両方おこなう。PATCHはなし